### PR TITLE
Make MAVLink packet aggregation feature optional

### DIFF
--- a/telemetry/proxy.py
+++ b/telemetry/proxy.py
@@ -89,6 +89,9 @@ class UDPProxyProtocol(DatagramProtocol):
             log.msg('Message too big: %d > %d' % (len(data), self.agg_max_size), isError=1)
             return
 
+        if not self.agg_timeout:
+            return self._send_to_peer(data)
+
         if self.agg_queue_size + len(data) > self.agg_max_size:
             # message doesn't fit into agg queue
             if self.agg_queue_timer is not None:


### PR DESCRIPTION
Sometimes (for the debug purposes or for vehicles with low-frequency telemetry to reduce latency) we want to disable MAVLink packets aggregation in the configuration file. This commit adds this possibility (`mavlink_agg_timeout = 0`).