### PR TITLE
Fix compilation on modern PCs (plus some README++)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ gst-launch-1.0 uvch264src device=/dev/video0 initial-bitrate=6000000 average-bit
                src.vidsrc ! queue ! video/x-h264,width=1920,height=1080,framerate=30/1 ! h264parse ! rtph264pay ! udpsink host=localhost port=5600
 ```
 
+To encode a Raspberry Pi Camera V2:
+```
+raspivid -n  -ex fixedfps -w 960 -h 540 -b 4000000 -fps 30 -vf -hf -t 0 -o - | \
+               gst-launch-1.0 -v fdsrc ! h264parse ! rtph264pay config-interval=1 pt=35 ! udpsink sync=false host=127.0.0.1 port=5600
+```
+
 To decode:
 ```
  gst-launch-1.0 udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' \

--- a/src/fec.h
+++ b/src/fec.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /**
  * zfec -- fast forward error correction library with Python interface
  * https://tahoe-lafs.org/trac/zfec/

--- a/src/ieee80211_radiotap.h
+++ b/src/ieee80211_radiotap.h
@@ -107,7 +107,7 @@ struct ieee80211_radiotap_header {
                                  * Additional extensions are made
                                  * by setting bit 31.
                                  */
-} __packed;
+} __attribute__ ((packed));
 
 /* Name                                 Data type    Units
  * ----                                 ---------    -----

--- a/src/rx.cpp
+++ b/src/rx.cpp
@@ -45,6 +45,8 @@ extern "C"
 #include "wifibroadcast.hpp"
 #include "rx.hpp"
 
+using namespace std;
+
 
 Receiver::Receiver(const char *wlan, int wlan_idx, int radio_port, BaseAggregator *agg) : wlan_idx(wlan_idx), agg(agg)
 {

--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -40,6 +40,8 @@ extern "C"
 #include "wifibroadcast.hpp"
 #include "tx.hpp"
 
+using namespace std;
+
 Transmitter::Transmitter(int k, int n, const string &keypair):  fec_k(k), fec_n(n), block_idx(0),
                                                                 fragment_idx(0),
                                                                 max_packet_size(0)

--- a/src/wifibroadcast.cpp
+++ b/src/wifibroadcast.cpp
@@ -7,8 +7,11 @@
 #include <arpa/inet.h>
 #include <string>
 #include <memory>
+#include <stdexcept>
 
 #include "wifibroadcast.hpp"
+
+using namespace std;
 
 string string_format(const char *format, ...)
 {

--- a/src/wifibroadcast.hpp
+++ b/src/wifibroadcast.hpp
@@ -34,13 +34,12 @@
 #include <sys/mman.h>
 #include <sodium.h>
 #include <endian.h>
+#include <string>
 
 #define MAX_PACKET_SIZE 1510
 #define MAX_RX_INTERFACES 8
 
-using namespace std;
-
-extern string string_format(const char *format, ...);
+extern std::string string_format(const char *format, ...);
 
 /* this is the template radiotap header we send packets out with */
 

--- a/version.py
+++ b/version.py
@@ -8,12 +8,12 @@ import datetime
 def main(release):
     ttuple = time.gmtime()
     if not release:
-        print '%d.%d.%d.%d' % (ttuple.tm_year - 2000, ttuple.tm_mon, ttuple.tm_mday,
-                               ttuple.tm_hour * 3600 + ttuple.tm_min * 60 + ttuple.tm_sec)
+        print ('%d.%d.%d.%d' % (ttuple.tm_year - 2000, ttuple.tm_mon, ttuple.tm_mday,
+                               ttuple.tm_hour * 3600 + ttuple.tm_min * 60 + ttuple.tm_sec))
     else:
         delta = datetime.datetime.utcnow() - datetime.datetime(2000 + release[0], release[1], 1)
-        print '%d.%d.%s.%d' % (release[0], release[1], '0.%d' % (999 + delta.days,) if delta.days < 0 else (delta.days + 1),
-                               ttuple.tm_hour * 3600 + ttuple.tm_min * 60 + ttuple.tm_sec)
+        print ('%d.%d.%s.%d' % (release[0], release[1], '0.%d' % (999 + delta.days,) if delta.days < 0 else (delta.days + 1),
+                               ttuple.tm_hour * 3600 + ttuple.tm_min * 60 + ttuple.tm_sec))
 
 if __name__ == '__main__':
     main(map(int, sys.argv[1].split('.')) if len(sys.argv) == 2 else None)


### PR DESCRIPTION
This PR consists of two parts. If desired, I can split it into multiple smaller PRs:

1. Fixing build on recent machines (such as Archlinux with Python3 and GCC10):
  - `/usr/bin/env python` will launch a Python3 interpreter, but the `version.py` script uses Python2-only syntax. Adding some parentheses helps here (while retaining Python2 compatibility)
  - Added lots of `#include` statements to make it build.
  - replaced the last remaining `__packed` with `__attribute__((packed))`.
2. Adds instructions about using the Raspberry Pi Camera with `raspivid`. No witchcraft going on here, but I thought it'd be nice to have this copy-paste-able.

I've tested this on my laptop running Archlinux (Python3, GCC10) and on Raspbian (Python2, GCC8), both work.