### PR TITLE
Fix python3 compatibility issue

### DIFF
--- a/telemetry/mavlink.py
+++ b/telemetry/mavlink.py
@@ -38,7 +38,10 @@ class x25crc(object):
         accum = self.crc
         import array
         bytes = array.array('B')
-        bytes.fromstring(buf)
+        if not (sys.version_info.major == 3 and sys.version_info.minor >= 2):
+                bytes.fromstring(buf)
+        else:
+                bytes.frombytes(buf)
         self.accumulate(bytes)
 
 


### PR DESCRIPTION
Proposed fix for #113 
Since Python3.2 , the function _array.fromstring()_ have been renamed to _array.frombytes()_.
This patch will check the version of python version prior in order to determine the rigth function to used.

It may be less efficient that way, but i do not see how to fix this issue otherwise.