### PR TITLE
Log rotation

### DIFF
--- a/scripts/wifibroadcast
+++ b/scripts/wifibroadcast
@@ -1,0 +1,7 @@
+/var/log/wifibroadcast.log {
+    rotate 4
+    weekly 1
+    compress
+    missingok
+    notifempty
+}

--- a/scripts/wifibroadcast@.service
+++ b/scripts/wifibroadcast@.service
@@ -10,6 +10,8 @@ ExecStart=/usr/bin/wfb-server %i ${WFB_NICS}
 TimeoutStopSec=5s
 Restart=on-failure
 RestartSec=5s
+StandardOutput=file:/var/log/wifibroadcast.log
+StandardError=inherit
 
 [Install]
 WantedBy=wifibroadcast.service

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(
                                            'scripts/wifibroadcast.service',
                                            'scripts/wifibroadcast@.service']),
                   ('/etc/default', ['scripts/default/wifibroadcast']),
-                  ('/etc/sysctl.d', ['scripts/98-wifibroadcast.conf'])],
+                  ('/etc/sysctl.d', ['scripts/98-wifibroadcast.conf']),
+                  ('/etc/logrotate.d', ['scripts/wifibroadcast'])],
 
     keywords="wifibroadcast",
     author="Vasily Evseenko",


### PR DESCRIPTION
Move logs from syslog to separate file: `/var/log/wifibroadcast.log`.
Add log rotation.